### PR TITLE
fix search_path logging error

### DIFF
--- a/lib/amber/render/view.rb
+++ b/lib/amber/render/view.rb
@@ -116,7 +116,7 @@ module Amber
             return path_with_locale if File.exist?(path_with_locale)
           end
         end
-        Amber.logger.error("No such path `#{path2}` from `#{page.content_file(locale)}`.")
+        Amber.logger.error("No such path `#{search_path}` from `#{page.content_file(locale)}`.")
         return nil
       end
 


### PR DESCRIPTION
Amber.logger resides beyond the scope of path2

```
ERROR: undefined local variable or method `path2' for #<Amber::Render::View:0xb3c34980>
Did you mean?  Pathname
ERROR: /home/user/amber/lib/amber/render/view.rb:119:in `find_file'
       /home/user/amber/lib/amber/render/view.rb:158:in `parse_render_options'
       /home/user/amber/lib/amber/render/view.rb:56:in `render'
       (__TEMPLATE__):5:in `block in singleton class'
       (__TEMPLATE__):131066:in `instance_eval'
       (__TEMPLATE__):131066:in `singleton class'
       (__TEMPLATE__):131064:in `__tilt_83457980'
       /var/lib/gems/2.3.0/gems/tilt-2.0.5/lib/tilt/template.rb:167:in `call'
       /var/lib/gems/2.3.0/gems/tilt-2.0.5/lib/tilt/template.rb:167:in `evaluate'
       /var/lib/gems/2.3.0/gems/tilt-2.0.5/lib/tilt/template.rb:102:in `render'
       /home/user/amber/lib/amber/render/template.rb:88:in `render_erb'
       /home/user/amber/lib/amber/render/template.rb:79:in `render_html'
       /home/user/amber/lib/amber/render/template.rb:55:in `render'
       /home/user/amber/lib/amber/render/view.rb:67:in `block in render'
```
